### PR TITLE
Add some new types to the API to help clarify

### DIFF
--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,8 +3,8 @@ module Test.Main where
 import Prelude
 
 import Control.Coroutine (Consumer, Producer, runProcess, consumer, ($$))
-import Control.Coroutine.Aff (Emission(..), emit, produceAff)
-import Control.Monad.Aff (Aff, runAff, delay)
+import Control.Coroutine.Aff (emit, close, produceAff)
+import Control.Monad.Aff (Aff, Milliseconds(..), delay, runAff)
 import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff)
@@ -12,18 +12,17 @@ import Control.Monad.Eff.Console (CONSOLE, log, logShow)
 import Control.Monad.Eff.Exception (EXCEPTION)
 import Data.Either (either)
 import Data.Maybe (Maybe(..))
-import Data.Newtype (wrap)
 
 p :: forall eff. Producer String (Aff (avar :: AVAR | eff)) String
 p = produceAff \emitter -> do
-  delay (wrap 1000.0)
-  emit emitter $ Step "Working..."
-  delay (wrap 1000.0)
-  emit emitter $ Step "Working..."
-  delay (wrap 1000.0)
-  emit emitter $ Step "Working..."
-  delay (wrap 1000.0)
-  emit emitter $ Result "Done!"
+  delay (Milliseconds 1000.0)
+  emit emitter "Working..."
+  delay (Milliseconds 1000.0)
+  emit emitter "Working..."
+  delay (Milliseconds 1000.0)
+  emit emitter "Working..."
+  delay (Milliseconds 1000.0)
+  close emitter "Done!"
 
 c :: forall eff. Consumer String (Aff (console :: CONSOLE | eff)) String
 c = consumer \s -> liftEff (log s) $> Nothing

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,28 +3,27 @@ module Test.Main where
 import Prelude
 
 import Control.Coroutine (Consumer, Producer, runProcess, consumer, ($$))
-import Control.Coroutine.Aff (produceAff)
+import Control.Coroutine.Aff (Emission(..), emit, produceAff)
 import Control.Monad.Aff (Aff, runAff, delay)
 import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (CONSOLE, log, logShow)
 import Control.Monad.Eff.Exception (EXCEPTION)
-
-import Data.Either (Either(..), either)
+import Data.Either (either)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (wrap)
 
 p :: forall eff. Producer String (Aff (avar :: AVAR | eff)) String
-p = produceAff \emit -> do
+p = produceAff \emitter -> do
   delay (wrap 1000.0)
-  emit $ Left "Working..."
+  emit emitter $ Step "Working..."
   delay (wrap 1000.0)
-  emit $ Left "Working..."
+  emit emitter $ Step "Working..."
   delay (wrap 1000.0)
-  emit $ Left "Working..."
+  emit emitter $ Step "Working..."
   delay (wrap 1000.0)
-  emit $ Right "Done!"
+  emit emitter $ Result "Done!"
 
 c :: forall eff. Consumer String (Aff (console :: CONSOLE | eff)) String
 c = consumer \s -> liftEff (log s) $> Nothing


### PR DESCRIPTION
People have a really hard time figuring this out, and I understand why, it didn't click for me either for a while, mainly due to the way `\recv ->` works. I talked a bit to Christoph about it, and in that conversation it occurred to me we can probably help a great deal just by throwing some types in the mix to hide some of the "low-level complexity" that the existing types expose.

Also nobody knows what the `Left` and `Right` mean for the emit, even though it does say in the comment, so similar to the `Step` we have in `MonadRec` I guess an either-iso is fine to use here to help too.

This is just an idea, I'm not precious about the names I've used here or anything, just thought I'd throw it out there to see what the reception would be. If we want to do this I'll add comments to the new stuff too.

/cc @paf31 @natefaubion @kRITZCREEK 