### PR TITLE
Fixed produce

### DIFF
--- a/psc-package.json
+++ b/psc-package.json
@@ -1,7 +1,7 @@
 {
     "name": "aff-coroutines",
     "source": "https://github.com/purescript/package-sets.git",
-    "set": "psc-0.10.1",
+    "set": "psc-0.11.7-20180524",
     "depends": [
       "aff",
       "arrays",

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,14 +3,13 @@ module Test.Main where
 import Prelude
 
 import Control.Coroutine (Consumer, Producer, runProcess, consumer, ($$))
-import Control.Coroutine.Aff (produceAff)
+import Control.Coroutine.Aff (produce, produceAff)
 import Control.Monad.Aff (Aff, runAff, delay)
 import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (CONSOLE, log, logShow)
 import Control.Monad.Eff.Exception (EXCEPTION)
-
 import Data.Either (Either(..), either)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (wrap)
@@ -26,8 +25,14 @@ p = produceAff \emit -> do
   delay (wrap 1000.0)
   emit $ Right "Done!"
 
+q = produce \emit -> do
+  log "Working..."
+  emit (Left "progress")
+  log "Done!"
+  emit (Right "finished")
+
 c :: forall eff. Consumer String (Aff (console :: CONSOLE | eff)) String
 c = consumer \s -> liftEff (log s) $> Nothing
 
 main :: forall eff. Eff (console :: CONSOLE, avar :: AVAR, err :: EXCEPTION | eff) Unit
-main = void $ runAff (either logShow log) $ runProcess (p $$ c)
+main = void $ runAff (either logShow log) $ runProcess (q $$ c)


### PR DESCRIPTION
This will fix issue #19 that I submitted yesterday. The problem was that the produce function did not work correctly, while produceAff did.

The correct working can be verified by running the example as given in the documentation:

produce \emitter -> do
  log "Working..."
  emit emitter "progress"
  log "Done!"
  close emitter "finished"

I must confess that I've never created a pull request before so I hope nothing goes wrong! To be sure rather than sorry: this should fix an issue in version v6.0.0.
