### PR TITLE
Add missing deps

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -1,6 +1,18 @@
 { name = "aff-coroutines"
 , dependencies =
-  [ "aff", "avar", "console", "coroutines", "effect", "psci-support" ]
+  [ "aff"
+  , "avar"
+  , "console"
+  , "coroutines"
+  , "effect"
+  , "either"
+  , "freet"
+  , "maybe"
+  , "newtype"
+  , "prelude"
+  , "psci-support"
+  , "transformers"
+  ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }


### PR DESCRIPTION
**Description of the change**

This adds missing dependencies listed when running `spago build` (see: https://github.com/purescript-contrib/governance/issues/43)

<details><summary>Output from running <code>spago build</code> before these changes</summary>

<pre>
[info] Build succeeded.
[error] Some of your project files import modules from packages that are not in the direct dependencies of your project.
To fix this error add the following packages to the list of dependencies in your config:
- either
- freet
- maybe
- newtype
- prelude
- transformers
You may add these dependencies by running the following command:
spago install either freet maybe newtype prelude transformers
</pre>

</details>

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
